### PR TITLE
Override setGain and getGainRange to avoid changing RFGR.

### DIFF
--- a/Settings.cpp
+++ b/Settings.cpp
@@ -653,6 +653,12 @@ void SoapySDRPlay::setGain(const int direction, const size_t channel, const std:
    }
 }
 
+void SoapySDRPlay::setGain(const int direction, const size_t channel, const double value)
+{
+   // Only IFGR should be used for adjusting the overall system gain.
+   this->setGain(direction, channel, "IFGR", value);
+}
+
 double SoapySDRPlay::getGain(const int direction, const size_t channel, const std::string &name) const
 {
     std::lock_guard <std::mutex> lock(_general_state_mutex);
@@ -667,6 +673,12 @@ double SoapySDRPlay::getGain(const int direction, const size_t channel, const st
    }
 
    return 0;
+}
+
+double SoapySDRPlay::getGain(const int direction, const size_t channel) const
+{
+   // Only IFGR should be used for adjusting the overall system gain.
+   return this->getGain(direction, channel, "IFGR");
 }
 
 SoapySDR::Range SoapySDRPlay::getGainRange(const int direction, const size_t channel, const std::string &name) const
@@ -696,6 +708,12 @@ SoapySDR::Range SoapySDRPlay::getGainRange(const int direction, const size_t cha
       return SoapySDR::Range(0, 27);
    }
     return SoapySDR::Range(20, 59);
+}
+
+SoapySDR::Range SoapySDRPlay::getGainRange(const int direction, const size_t channel) const
+{
+   // Only IFGR should be used for adjusting the overall system gain.
+   return this->getGainRange(direction, channel, "IFGR");
 }
 
 /*******************************************************************

--- a/SoapySDRPlay.hpp
+++ b/SoapySDRPlay.hpp
@@ -146,9 +146,15 @@ public:
 
     void setGain(const int direction, const size_t channel, const std::string &name, const double value);
 
+    void setGain(const int direction, const size_t channel, const double value);
+
     double getGain(const int direction, const size_t channel, const std::string &name) const;
 
+    double getGain(const int direction, const size_t channel) const;
+
     SoapySDR::Range getGainRange(const int direction, const size_t channel, const std::string &name) const;
+
+    SoapySDR::Range getGainRange(const int direction, const size_t channel) const;
 
     /*******************************************************************
      * Frequency API


### PR DESCRIPTION
SDRPlay's "RFGR" is actually a mode selector for the front-end LNA. It does *not* have units of dB. (In fact, the resulting gain is frequency-dependent.) As a result, the default gain allocation algorithm does not apply and only IFGR should be used for automatic adjustment of the overall system gain.

(See https://github.com/pothosware/SoapySDRPlay2/issues/60 for previous discussion, https://www.sdrplay.com/docs/SDRplay_SDR_API_Specification.pdf section 5.3 for the definition of RFGR.)