### PR TITLE
Reconcile SDRPlay gains with SoapySDR abstractions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,11 +32,12 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     add_definitions(-Wno-unused-parameter)
 endif(CMAKE_COMPILER_IS_GNUCXX)
 
-# Configurable feature set
-SET (RF_GAIN_IN_MENU ON CACHE BOOL "Add Rf gain as a setting, additionally to the IFGR gain control")
+# The SDRPlay LNA state, aka "RF gain", is more properly a setting than a gain.
+# However, some users may prefer to also expose it as a SoapySDR gain.
+SET (LNA_STATE_AS_GAIN OFF CACHE BOOL "Duplicate the lna_state setting as a SoapySDR gain.")
 
-IF(RF_GAIN_IN_MENU)
-    ADD_DEFINITIONS( -DRF_GAIN_IN_MENU=1 )
+IF(LNA_STATE_AS_GAIN)
+    ADD_DEFINITIONS( -DLNA_STATE_AS_GAIN=1 )
 ENDIF()
 
 SET (STREAMING_USB_MODE_BULK OFF CACHE BOOL "Use USB bulk mode instead of isochronous")

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -653,6 +653,12 @@ void SoapySDRPlay::setGain(const int direction, const size_t channel, const std:
    }
 }
 
+void SoapySDRPlay::setGain(const int direction, const size_t channel, const double value)
+{
+   // Only IFGR should be used for adjusting the overall system gain.
+   this->setGain(direction, channel, "IFGR", value);
+}
+
 double SoapySDRPlay::getGain(const int direction, const size_t channel, const std::string &name) const
 {
     std::lock_guard <std::mutex> lock(_general_state_mutex);
@@ -667,6 +673,12 @@ double SoapySDRPlay::getGain(const int direction, const size_t channel, const st
    }
 
    return 0;
+}
+
+double SoapySDRPlay::getGain(const int direction, const size_t channel) const
+{
+   // Only IFGR should be used for adjusting the overall system gain.
+   return this->getGain(direction, channel, "IFGR");
 }
 
 SoapySDR::Range SoapySDRPlay::getGainRange(const int direction, const size_t channel, const std::string &name) const
@@ -696,6 +708,12 @@ SoapySDR::Range SoapySDRPlay::getGainRange(const int direction, const size_t cha
       return SoapySDR::Range(0, 27);
    }
     return SoapySDR::Range(20, 59);
+}
+
+SoapySDR::Range SoapySDRPlay::getGainRange(const int direction, const size_t channel) const
+{
+   // Only IFGR should be used for adjusting the overall system gain.
+   return this->getGainRange(direction, channel, "IFGR");
 }
 
 /*******************************************************************

--- a/SoapySDRPlay.hpp
+++ b/SoapySDRPlay.hpp
@@ -262,6 +262,7 @@ private:
     sdrplay_api_DeviceParamsT *deviceParams;
     sdrplay_api_RxChannelParamsT *chParams;
     std::string hardwareKey;
+    int maxLnaState;
 
     //cached settings
     double outputSampleRate;

--- a/SoapySDRPlay.hpp
+++ b/SoapySDRPlay.hpp
@@ -146,9 +146,15 @@ public:
 
     void setGain(const int direction, const size_t channel, const std::string &name, const double value);
 
+    void setGain(const int direction, const size_t channel, const double value);
+
     double getGain(const int direction, const size_t channel, const std::string &name) const;
 
+    double getGain(const int direction, const size_t channel) const;
+
     SoapySDR::Range getGainRange(const int direction, const size_t channel, const std::string &name) const;
+
+    SoapySDR::Range getGainRange(const int direction, const size_t channel) const;
 
     /*******************************************************************
      * Frequency API


### PR DESCRIPTION
Good morning and a happy new year to all!

This PR is an attempt to reconcile the unusual SDRPlay gains with the standard SoapySDR abstractions as cleanly as possible. It solves https://github.com/pothosware/SoapySDRPlay2/issues/44. This is a port of  https://github.com/pothosware/SoapySDRPlay2/pull/61 to the new version 3 driver.

(The first commit is a solution to https://github.com/pothosware/SoapySDRPlay2/issues/60; I also opened a separate PR https://github.com/pothosware/SoapySDRPlay3/pull/25 with just that commit.)

A brief summary of the changes:

1. SoapySDR and various SoapySDR clients expect that a larger gain results in more amplification. However, SDRPlay exposes a gain *reduction*, resulting in backwards controls and/or unstable AGC loops in generic SoapySDR clients. The solution is to define the gain to be equal to the *negative* of the gain reduction. For example, if a radio has an IF *gain reduction* range of 20 to 59 dB, this will now be exposed as an IF *gain* with a range of -20 to -59 dB.

2. A slightly thornier issue is that the "RF gain reduction" setting is not actually a gain setting in dB, but rather a mode selection for the front-end LNA. Semantically, it belongs in the settings and not in the gains. However, for the convenience of users who prefer to have the LNA setting available as a gain, a build option is provided. As with the IF gain, RF gain reduction values are negated so that larger values result in greater amplification.

I have built and tested this PR with the SDRPlay driver version 3.07 and an RSP1A on Debian Linux.

References:
1. Block diagram of RF and IF gains: [SDRPlay application note](https://www.sdrplay.com/wp-content/uploads/2018/06/Gain_and_AGC_in_SDRuno.pdf)
2. Actual dB losses caused by RF Gain setting: [SDRPlay API documentation](https://www.sdrplay.com/docs/SDRplay_SDR_API_Specification.pdf), section 5.3