### PR TITLE
Wait for frequency, sample rate, and gain updates to be fully completed before returning to client

### DIFF
--- a/SoapySDRPlay.hpp
+++ b/SoapySDRPlay.hpp
@@ -218,7 +218,7 @@ public:
      ******************************************************************/
 
     class SoapySDRPlayStream;
-    void rx_callback(short *xi, short *xq, unsigned int numSamples, SoapySDRPlayStream *stream);
+    void rx_callback(short *xi, short *xq, sdrplay_api_StreamCbParamsT *params, unsigned int numSamples, SoapySDRPlayStream *stream);
 
     void ev_callback(sdrplay_api_EventT eventId, sdrplay_api_TunerSelectT tuner, sdrplay_api_EventParamsT *params);
 
@@ -293,6 +293,12 @@ private:
     const int uninitRetryDelay = 10;   // 10 seconds before trying uninit again 
 
     static std::unordered_map<std::string, sdrplay_api_DeviceT*> selectedRSPDevices;
+
+    // RX callback reporting changes to gain reduction, frequency, sample rate
+    int gr_changed;
+    int rf_changed;
+    int fs_changed;
+    const int updateTimeout = 500;   // 500ms timeout for updates
 
 public:
 

--- a/Streaming.cpp
+++ b/Streaming.cpp
@@ -93,8 +93,6 @@ void SoapySDRPlay::rx_callback(short *xi, short *xq,
     {
         rf_changed = params->rfChanged;
     }
-// fv
-if (params->fsChanged) std::cerr << "fsChanged=" << params->fsChanged << std::endl;
     if (fs_changed == 0 && params->fsChanged != 0)
     {
         fs_changed = params->fsChanged;

--- a/Streaming.cpp
+++ b/Streaming.cpp
@@ -25,6 +25,7 @@
  */
 
 #include "SoapySDRPlay.hpp"
+#include <iostream>
 
 std::vector<std::string> SoapySDRPlay::getStreamFormats(const int direction, const size_t channel) const
 {
@@ -57,14 +58,14 @@ static void _rx_callback_A(short *xi, short *xq, sdrplay_api_StreamCbParamsT *pa
                            unsigned int numSamples, unsigned int reset, void *cbContext)
 {
     SoapySDRPlay *self = (SoapySDRPlay *)cbContext;
-    return self->rx_callback(xi, xq, numSamples, self->_streams[0]);
+    return self->rx_callback(xi, xq, params, numSamples, self->_streams[0]);
 }
 
 static void _rx_callback_B(short *xi, short *xq, sdrplay_api_StreamCbParamsT *params,
                            unsigned int numSamples, unsigned int reset, void *cbContext)
 {
     SoapySDRPlay *self = (SoapySDRPlay *)cbContext;
-    return self->rx_callback(xi, xq, numSamples, self->_streams[1]);
+    return self->rx_callback(xi, xq, params, numSamples, self->_streams[1]);
 }
 
 static void _ev_callback(sdrplay_api_EventT eventId, sdrplay_api_TunerSelectT tuner,
@@ -74,13 +75,30 @@ static void _ev_callback(sdrplay_api_EventT eventId, sdrplay_api_TunerSelectT tu
     return self->ev_callback(eventId, tuner, params);
 }
 
-void SoapySDRPlay::rx_callback(short *xi, short *xq, unsigned int numSamples,
+void SoapySDRPlay::rx_callback(short *xi, short *xq,
+                               sdrplay_api_StreamCbParamsT *params,
+                               unsigned int numSamples,
                                SoapySDRPlayStream *stream)
 {
     if (stream == 0) {
         return;
     }
     std::lock_guard<std::mutex> lock(stream->mutex);
+
+    if (gr_changed == 0 && params->grChanged != 0)
+    {
+        gr_changed = params->grChanged;
+    }
+    if (rf_changed == 0 && params->rfChanged != 0)
+    {
+        rf_changed = params->rfChanged;
+    }
+// fv
+if (params->fsChanged) std::cerr << "fsChanged=" << params->fsChanged << std::endl;
+    if (fs_changed == 0 && params->fsChanged != 0)
+    {
+        fs_changed = params->fsChanged;
+    }
 
     if (stream->count == numBuffers)
     {


### PR DESCRIPTION
Code changes to make the SoapySDR methods for frequency, sample rate, and gain changes wait until the hardware has actually changed to the new value before returning