### PR TITLE
Log a message when IFGR settings are ignored because of AGC

### DIFF
--- a/Settings.cpp
+++ b/Settings.cpp
@@ -489,6 +489,10 @@ void SoapySDRPlay::setGain(const int direction, const size_t channel, const std:
          doUpdate = true;
       }
    }
+   else if (name == "IFGR")
+   {
+      SoapySDR_log(SOAPY_SDR_WARNING, "Not updating IFGR gain because AGC is enabled");
+   }
    else if (name == "RFGR")
    {
       if (chParams->tunerParams.gain.LNAstate != (int)value) {


### PR DESCRIPTION
This confused me for awhile - IFGR settings are completely ignored when the AGC is enabled, and there's no error presented when that happens.