### PR TITLE
Preventing Soapy from messing frequency correction (ppm)

### DIFF
--- a/Settings.cpp
+++ b/Settings.cpp
@@ -573,6 +573,14 @@ SoapySDR::Range SoapySDRPlay::getGainRange(const int direction, const size_t cha
 
 void SoapySDRPlay::setFrequency(const int direction,
                                  const size_t channel,
+                                 const double frequency,
+                                 const SoapySDR::Kwargs &args)
+{
+    setFrequency(direction, channel, "RF", frequency, args);
+}
+
+void SoapySDRPlay::setFrequency(const int direction,
+                                 const size_t channel,
                                  const std::string &name,
                                  const double frequency,
                                  const SoapySDR::Kwargs &args)
@@ -614,6 +622,11 @@ void SoapySDRPlay::setFrequency(const int direction,
    }
 }
 
+double SoapySDRPlay::getFrequency(const int direction, const size_t channel) const
+{
+    return getFrequency(direction, channel, "RF");
+}
+
 double SoapySDRPlay::getFrequency(const int direction, const size_t channel, const std::string &name) const
 {
     std::lock_guard <std::mutex> lock(_general_state_mutex);
@@ -641,6 +654,11 @@ std::vector<std::string> SoapySDRPlay::listFrequencies(const int direction, cons
     names.push_back("RF");
     names.push_back("CORR");
     return names;
+}
+
+SoapySDR::RangeList SoapySDRPlay::getFrequencyRange(const int direction, const size_t channel) const
+{
+    return getFrequencyRange(direction, channel, "RF");
 }
 
 SoapySDR::RangeList SoapySDRPlay::getFrequencyRange(const int direction, const size_t channel,  const std::string &name) const

--- a/SoapySDRPlay.hpp
+++ b/SoapySDRPlay.hpp
@@ -160,15 +160,24 @@ public:
 
     void setFrequency(const int direction,
                       const size_t channel,
+                      const double frequency,
+                      const SoapySDR::Kwargs &args = SoapySDR::Kwargs());
+
+    void setFrequency(const int direction,
+                      const size_t channel,
                       const std::string &name,
                       const double frequency,
                       const SoapySDR::Kwargs &args = SoapySDR::Kwargs());
+
+    double getFrequency(const int direction, const size_t channel) const;
 
     double getFrequency(const int direction, const size_t channel, const std::string &name) const;
 
     SoapySDR::RangeList getBandwidthRange(const int direction, const size_t channel) const;
 
     std::vector<std::string> listFrequencies(const int direction, const size_t channel) const;
+
+    SoapySDR::RangeList getFrequencyRange(const int direction, const size_t channel) const;
 
     SoapySDR::RangeList getFrequencyRange(const int direction, const size_t channel, const std::string &name) const;
 


### PR DESCRIPTION
The default setFrequency() implementation in Soapy will try to "distribute" given frequency over all available frequency components. So, it will set the RF component to the given frequency, then set the CORR component to 0.

This causes the frequency correction (aka ppm) to always reset after a setFrequency() call, breaking ppm functionality in such packages as OpenWebRX.

The proposed change makes setFrequency() and related methods default to the RF component. The CORR component is left alone and can be used to correct frequency settings on per-device basis.