### PR TITLE
Adding separate default gain behaviors, ifgr-only and legacy.

### DIFF
--- a/Settings.cpp
+++ b/Settings.cpp
@@ -49,10 +49,6 @@ SoapySDRPlay::SoapySDRPlay(const SoapySDR::Kwargs &args)
                  args.count("mode") ? args.at("mode") : "",
                  args.count("antenna") ? args.at("antenna") : "");
 
-    // set default gain behavior
-    gain_behavior = args.count("gain_behavior") && args.at("gain_behavior") == "ifgr"?
-        GAIN_IFGR_ONLY : GAIN_DEFAULT;
-
     // keep all the default settings:
     // - rf: 200MHz
     // - fs: 2MHz
@@ -1250,6 +1246,14 @@ SoapySDR::ArgInfoList SoapySDRPlay::getSettingInfo(void) const
     }
 #endif
 
+    SoapySDR::ArgInfo DefGainArg;
+    DefGainArg.key = "default_gain";
+    DefGainArg.value = "legacy";
+    DefGainArg.name = "Default Gain Behavior";
+    DefGainArg.description = "Default Gain Behavior";
+    DefGainArg.type = SoapySDR::ArgInfo::STRING;
+    setArgs.push_back(DefGainArg);
+
     SoapySDR::ArgInfo IQcorrArg;
     IQcorrArg.key = "iqcorr_ctrl";
     IQcorrArg.value = "true";
@@ -1410,7 +1414,11 @@ void SoapySDRPlay::writeSetting(const std::string &key, const std::string &value
    }
    else
 #endif
-   if (key == "iqcorr_ctrl")
+   if (key == "default_gain")
+   {
+      gain_behavior = value == "ifgr"? GAIN_IFGR_ONLY : GAIN_DEFAULT;
+   }
+   else if (key == "iqcorr_ctrl")
    {
       if (value == "false") chParams->ctrlParams.dcOffset.IQenable = 0;
       else                  chParams->ctrlParams.dcOffset.IQenable = 1;
@@ -1584,7 +1592,11 @@ std::string SoapySDRPlay::readSetting(const std::string &key) const
     }
     else
 #endif
-    if (key == "iqcorr_ctrl")
+    if (key == "default_gain")
+    {
+       return gain_behavior == GAIN_IFGR_ONLY? "ifgr" : "legacy";
+    }
+    else if (key == "iqcorr_ctrl")
     {
        if (chParams->ctrlParams.dcOffset.IQenable == 0) return "false";
        else                                             return "true";

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -481,6 +481,7 @@ void SoapySDRPlay::setGain(const int direction, const size_t channel, const doub
         case GAIN_IFGR_ONLY:
             setGain(direction, channel, "IFGR", value);
             break;
+        case GAIN_DEFAULT:
         default:
             SoapySDR::Device::setGain(direction, channel, value);
             break;
@@ -542,6 +543,7 @@ double SoapySDRPlay::getGain(const int direction, const size_t channel) const
         case GAIN_IFGR_ONLY:
             return getGain(direction, channel, "IFGR");
             break;
+        case GAIN_DEFAULT:
         default:
             return SoapySDR::Device::getGain(direction, channel);
             break;
@@ -571,6 +573,7 @@ SoapySDR::Range SoapySDRPlay::getGainRange(const int direction, const size_t cha
         case GAIN_IFGR_ONLY:
             return getGainRange(direction, channel, "IFGR");
             break;
+        case GAIN_DEFAULT:
         default:
             return SoapySDR::Device::getGainRange(direction, channel);
             break;
@@ -1247,7 +1250,7 @@ SoapySDR::ArgInfoList SoapySDRPlay::getSettingInfo(void) const
 #endif
 
     SoapySDR::ArgInfo DefGainArg;
-    DefGainArg.key = "default_gain";
+    DefGainArg.key = "gain_behavior";
     DefGainArg.value = "legacy";
     DefGainArg.name = "Default Gain Behavior";
     DefGainArg.description = "Default Gain Behavior";
@@ -1414,7 +1417,7 @@ void SoapySDRPlay::writeSetting(const std::string &key, const std::string &value
    }
    else
 #endif
-   if (key == "default_gain")
+   if (key == "gain_behavior")
    {
       gain_behavior = value == "ifgr"? GAIN_IFGR_ONLY : GAIN_DEFAULT;
    }
@@ -1592,7 +1595,7 @@ std::string SoapySDRPlay::readSetting(const std::string &key) const
     }
     else
 #endif
-    if (key == "default_gain")
+    if (key == "gain_behavior")
     {
        return gain_behavior == GAIN_IFGR_ONLY? "ifgr" : "legacy";
     }

--- a/SoapySDRPlay.hpp
+++ b/SoapySDRPlay.hpp
@@ -45,6 +45,9 @@
 #define DEFAULT_NUM_BUFFERS       (8)
 #define DEFAULT_ELEMS_PER_SAMPLE  (2)
 
+#define GAIN_DEFAULT              (0)
+#define GAIN_IFGR_ONLY            (1)
+
 std::set<std::string> &SoapySDRPlay_getClaimedSerials(void);
 
 class SoapySDRPlay: public SoapySDR::Device
@@ -148,9 +151,15 @@ public:
 
     bool getGainMode(const int direction, const size_t channel) const;
 
+    void setGain(const int direction, const size_t channel, const double value);
+
     void setGain(const int direction, const size_t channel, const std::string &name, const double value);
 
+    double getGain(const int direction, const size_t channel) const;
+
     double getGain(const int direction, const size_t channel, const std::string &name) const;
+
+    SoapySDR::Range getGainRange(const int direction, const size_t channel) const;
 
     SoapySDR::Range getGainRange(const int direction, const size_t channel, const std::string &name) const;
 
@@ -283,6 +292,9 @@ private:
     const size_t numBuffers = DEFAULT_NUM_BUFFERS;
     const unsigned int bufferElems = DEFAULT_BUFFER_LENGTH;
     const int elementsPerSample = DEFAULT_ELEMS_PER_SAMPLE;
+
+    //default gain control behavior
+    int gain_behavior = GAIN_DEFAULT;
 
     std::atomic_uint shortsPerWord;
  

--- a/SoapySDRPlay.hpp
+++ b/SoapySDRPlay.hpp
@@ -294,7 +294,7 @@ private:
     const int elementsPerSample = DEFAULT_ELEMS_PER_SAMPLE;
 
     //default gain control behavior
-    int gain_behavior = GAIN_DEFAULT;
+    int gain_behavior = GAIN_IFGR_ONLY;
 
     std::atomic_uint shortsPerWord;
  


### PR DESCRIPTION
Added two default gain (setGain() with no name) behaviors: IFGR-only and default (aka legacy). These can be switched with the initial "gain_behavior" parameter, set to "ifgr" for IFGR_only gain behavior.

It is worth noting that the default setGain() behavior in Soapy is incorrect w.r.t. SDRPlay device gains, so it is not really worth keeping around, other than to please people who do not own or use SDRPlay devices.

It is also worth noting that the proposed change allows for adding more gain behaviors, such as the new gain computation algorithm discussed in several issue threads.