### PR TITLE
Update fix

### DIFF
--- a/Settings.cpp
+++ b/Settings.cpp
@@ -1937,7 +1937,7 @@ sdrplay_api_ErrT SoapySDRPlay::tryUpdate(sdrplay_api_ReasonForUpdateT reasonForU
         }
         else
         {
-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
         }
     }
 

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -1926,7 +1926,7 @@ void SoapySDRPlay::releaseDevice()
 
 sdrplay_api_ErrT SoapySDRPlay::tryUpdate(sdrplay_api_ReasonForUpdateT reasonForUpdate)
 {
-    sdrplay_api_ErrT err;
+    sdrplay_api_ErrT err = sdrplay_api_Success;
 
     for (int i = 0 ; i < retryCount; ++i)
     {

--- a/SoapySDRPlay.hpp
+++ b/SoapySDRPlay.hpp
@@ -274,6 +274,7 @@ private:
 
     void releaseDevice();
 
+    sdrplay_api_ErrT tryUpdate(sdrplay_api_ReasonForUpdateT reasonForUpdate);
 
     /*******************************************************************
      * Private variables
@@ -316,6 +317,7 @@ private:
     // event callback reporting device is unavailable
     bool device_unavailable;
     const int updateTimeout = 500;   // 500ms timeout for updates
+    const int retryCount = 3;        // number of sdrplay_api_Update() retries
 
 public:
 


### PR DESCRIPTION
This fix will make SoapySDRPlay3 retry sdrplay_api_Update() call several times (up to 3 with the current setting), or until it succeeds.

Have been testing it several days and so far it appears to completely fix random failures to set radio parameters in OpenWebRX.