### PR TITLE
Minor improvements to new-gain-controls

### DIFF
--- a/Settings.cpp
+++ b/Settings.cpp
@@ -1438,7 +1438,12 @@ void SoapySDRPlay::writeSetting(const std::string &key, const std::string &value
       if (streamActive)
       {
          gr_changed = 0;
-         sdrplay_api_Update(device.dev, device.tuner, sdrplay_api_Update_Tuner_Gr, sdrplay_api_Update_Ext1_None);
+         sdrplay_api_ErrT err = sdrplay_api_Update(device.dev, device.tuner, sdrplay_api_Update_Tuner_Gr, sdrplay_api_Update_Ext1_None);
+         if (err != sdrplay_api_Success)
+         {
+            SoapySDR_logf(SOAPY_SDR_WARNING, "sdrplay_api_Update(Tuner_Gr) Error: %s", sdrplay_api_GetErrorString(err));
+            return;
+         }
          for (int i = 0; i < updateTimeout; ++i)
          {
             if (gr_changed != 0) {
@@ -1676,7 +1681,7 @@ void SoapySDRPlay::writeSetting(const std::string &key, const std::string &value
       } else if (value == "ifgr" || value == "IFGR") {
          gain_controls = new GainControlsIFGR(device, chParams);
       } else {
-         SoapySDR_logf(SOAPY_SDR_WARNING, "Invalid gain_ctrl_mode: %s", value);
+         SoapySDR_logf(SOAPY_SDR_WARNING, "Invalid gain_ctrl_mode: %s", value.c_str());
       }
    }
 }
@@ -1765,6 +1770,8 @@ std::string SoapySDRPlay::readSetting(const std::string &key) const
        if (hdrEn == 0) return "false";
        else            return "true";
     }
+    //else if (key == "gain_ctrl_mode") //TODO
+      // return gain_controls->getGainControlModeKeyValue();
 
     // SoapySDR_logf(SOAPY_SDR_WARNING, "Unknown setting '%s'", key.c_str());
     return "";

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -1770,10 +1770,26 @@ std::string SoapySDRPlay::readSetting(const std::string &key) const
        if (hdrEn == 0) return "false";
        else            return "true";
     }
-    //else if (key == "gain_ctrl_mode") //TODO
-      // return gain_controls->getGainControlModeKeyValue();
+    else if (key == "gain_ctrl_mode") 
+    {
+       if (dynamic_cast<GainControlsLegacy *>(gain_controls)) {
+          return "LEGACY";
+       } else if (dynamic_cast<GainControlsDB *>(gain_controls)) {
+          return "DB";
+       } else if (dynamic_cast<GainControlsRFATT *>(gain_controls)) {
+          return "RFATT";
+       } else if (dynamic_cast<GainControlsSteps *>(gain_controls)) {
+          return "STEPS";
+       } else if (dynamic_cast<GainControlsIFGR *>(gain_controls)) {
+          return "IFGR";
+       } else {
+          SoapySDR_logf(SOAPY_SDR_WARNING, "Unknown setting string for gain_ctrl_mode");
+          return "";
+       }
+       
+    }
 
-    // SoapySDR_logf(SOAPY_SDR_WARNING, "Unknown setting '%s'", key.c_str());
+    SoapySDR_logf(SOAPY_SDR_WARNING, "Unknown setting '%s'", key.c_str());
     return "";
 }
 


### PR DESCRIPTION
This PR includes one substantial change and two changes to error logging:

- `readSetting()` now reports the correct setting for `gain_ctrl_mode`
- The log message for unknown `gain_ctrl_mode `was being passed a `std::string` for a `%s` argument
- There was no warning for a failed call to `sdrplay_api_Update()` (I don't remember doing this - I think it must have come from the `master` branch?)

I used the `dynamic_cast<>()` approach to getting the gain control mode. I don't really like it - `dynamic_cast` rings alarm bells - but I think it's slightly more consistent than the approach I took in `new-gain-controls-ollie`.
