### PR TITLE
Tdoa rspduo dt ir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 *~
 *.swp
+PR-description

--- a/Registration.cpp
+++ b/Registration.cpp
@@ -41,6 +41,12 @@ static std::vector<SoapySDR::Kwargs> findSDRPlay(const SoapySDR::Kwargs &args)
 
    std::string baseLabel = "SDRplay Dev";
 
+   bool isDualTunerIndependentRxHint = false;
+   if (args.count("rspduo_dual_tuner_independent_rx") != 0)
+   {
+      isDualTunerIndependentRxHint = args.at("rspduo_dual_tuner_independent_rx") == "true";
+   }
+
    // list devices by API
    SoapySDRPlay::sdrplay_api::get_instance();
    sdrplay_api_LockDeviceApi();
@@ -109,13 +115,29 @@ static std::vector<SoapySDR::Kwargs> findSDRPlay(const SoapySDR::Kwargs &args)
       if (rspDevs[i].rspDuoMode & sdrplay_api_RspDuoMode_Dual_Tuner)
       {
          dev["mode"] = "DT";
-         const bool modeMatch = args.count("mode") == 0 or args.at("mode") == dev["mode"];
+         const bool modeMatch = (args.count("mode") == 0 or args.at("mode") == dev["mode"]) &&
+                                !isDualTunerIndependentRxHint;
          if (modeMatch)
          {
             sprintf_s(lblstr, sizeof(lblstr), "SDRplay Dev%ld %s %s - Dual Tuner", results.size(), modelName.c_str(), rspDevs[i].SerNo);
             dev["label"] = lblstr;
             results.push_back(dev);
             _cachedResults[dev["serial"] + "@" + dev["mode"]] = dev;
+         }
+      }
+      if (rspDevs[i].rspDuoMode & sdrplay_api_RspDuoMode_Dual_Tuner)
+      {
+         SoapySDR::Kwargs dtir_dev = dev;
+         dtir_dev["mode"] = "DT-IR";
+         dtir_dev["rspduo_dual_tuner_independent_rx"] = "true";
+         const bool modeMatch = (args.count("mode") == 0 or args.at("mode") == dtir_dev["mode"]) &&
+                                (isDualTunerIndependentRxHint || args.count("rspduo_dual_tuner_independent_rx") == 0);
+         if (modeMatch)
+         {
+            sprintf_s(lblstr, sizeof(lblstr), "SDRplay Dev%ld %s %s - Dual Tuner (independent RX)", results.size(), modelName.c_str(), rspDevs[i].SerNo);
+            dtir_dev["label"] = lblstr;
+            results.push_back(dtir_dev);
+            _cachedResults[dtir_dev["serial"] + "@DT-IR"] = dtir_dev;
          }
       }
       if (rspDevs[i].rspDuoMode & sdrplay_api_RspDuoMode_Master)

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -517,12 +517,13 @@ void SoapySDRPlay::setGainMode(const int direction, const size_t channel, const 
     std::lock_guard <std::mutex> lock(_general_state_mutex);
 
     sdrplay_api_AgcControlT agc_control = automatic ? sdrplay_api_AGC_CTRL_EN : sdrplay_api_AGC_DISABLE;
-    if (chParams->ctrlParams.agc.enable != agc_control)
+    sdrplay_api_RxChannelParamsT *chp = getChParams(channel);
+    if (chp->ctrlParams.agc.enable != agc_control)
     {
-        chParams->ctrlParams.agc.enable = agc_control;
+        chp->ctrlParams.agc.enable = agc_control;
         if (streamActive)
         {
-            sdrplay_api_Update(device.dev, device.tuner, sdrplay_api_Update_Ctrl_Agc, sdrplay_api_Update_Ext1_None);
+            sdrplay_api_Update(device.dev, getChTuner(channel), sdrplay_api_Update_Ctrl_Agc, sdrplay_api_Update_Ext1_None);
         }
     }
 }
@@ -531,7 +532,8 @@ bool SoapySDRPlay::getGainMode(const int direction, const size_t channel) const
 {
     std::lock_guard <std::mutex> lock(_general_state_mutex);
 
-    return chParams->ctrlParams.agc.enable != sdrplay_api_AGC_DISABLE;
+    sdrplay_api_RxChannelParamsT *chp = getChParams(channel);
+    return chp->ctrlParams.agc.enable != sdrplay_api_AGC_DISABLE;
 }
 
 void SoapySDRPlay::setGain(const int direction, const size_t channel, const std::string &name, const double value)
@@ -540,14 +542,15 @@ void SoapySDRPlay::setGain(const int direction, const size_t channel, const std:
 
    bool doUpdate = false;
 
+   sdrplay_api_RxChannelParamsT *chp = getChParams(channel);
    if (name == "IFGR")
    {
-      if (chParams->ctrlParams.agc.enable == sdrplay_api_AGC_DISABLE)
+      if (chp->ctrlParams.agc.enable == sdrplay_api_AGC_DISABLE)
       {
          //apply the change if the required value is different from gRdB
-         if (chParams->tunerParams.gain.gRdB != (int)value)
+         if (chp->tunerParams.gain.gRdB != (int)value)
          {
-            chParams->tunerParams.gain.gRdB = (int)value;
+            chp->tunerParams.gain.gRdB = (int)value;
             doUpdate = true;
          }
       }
@@ -558,15 +561,15 @@ void SoapySDRPlay::setGain(const int direction, const size_t channel, const std:
    }
    else if (name == "RFGR")
    {
-      if (chParams->tunerParams.gain.LNAstate != (int)value) {
-          chParams->tunerParams.gain.LNAstate = (int)value;
+      if (chp->tunerParams.gain.LNAstate != (int)value) {
+          chp->tunerParams.gain.LNAstate = (int)value;
           doUpdate = true;
       }
    }
    if ((doUpdate == true) && (streamActive))
    {
       gr_changed = 0;
-      sdrplay_api_ErrT err = sdrplay_api_Update(device.dev, device.tuner, sdrplay_api_Update_Tuner_Gr, sdrplay_api_Update_Ext1_None);
+      sdrplay_api_ErrT err = sdrplay_api_Update(device.dev, getChTuner(channel), sdrplay_api_Update_Tuner_Gr, sdrplay_api_Update_Ext1_None);
       if (err != sdrplay_api_Success)
       {
          SoapySDR_logf(SOAPY_SDR_WARNING, "sdrplay_api_Update(Tuner_Gr) Error: %s", sdrplay_api_GetErrorString(err));
@@ -590,13 +593,14 @@ double SoapySDRPlay::getGain(const int direction, const size_t channel, const st
 {
     std::lock_guard <std::mutex> lock(_general_state_mutex);
 
+   sdrplay_api_RxChannelParamsT *chp = getChParams(channel);
    if (name == "IFGR")
    {
-       return chParams->tunerParams.gain.gRdB;
+       return chp->tunerParams.gain.gRdB;
    }
    else if (name == "RFGR")
    {
-      return chParams->tunerParams.gain.LNAstate;
+      return chp->tunerParams.gain.LNAstate;
    }
 
    return 0;
@@ -671,13 +675,14 @@ void SoapySDRPlay::setFrequency(const int direction,
             SoapySDR_logf(SOAPY_SDR_WARNING, "RF center frequency out of range - frequency=%lg", frequency);
             return;
          }
-         if (chParams->tunerParams.rfFreq.rfHz != (uint32_t)frequency)
+         sdrplay_api_RxChannelParamsT *chp = getChParams(channel);
+         if (chp->tunerParams.rfFreq.rfHz != (uint32_t)frequency)
          {
-            chParams->tunerParams.rfFreq.rfHz = (uint32_t)frequency;
+            chp->tunerParams.rfFreq.rfHz = (uint32_t)frequency;
             if (streamActive)
             {
                rf_changed = 0;
-               sdrplay_api_ErrT err = sdrplay_api_Update(device.dev, device.tuner, sdrplay_api_Update_Tuner_Frf, sdrplay_api_Update_Ext1_None);
+               sdrplay_api_ErrT err = sdrplay_api_Update(device.dev, getChTuner(channel), sdrplay_api_Update_Tuner_Frf, sdrplay_api_Update_Ext1_None);
                if (err != sdrplay_api_Success)
                {
                   SoapySDR_logf(SOAPY_SDR_WARNING, "sdrplay_api_Update(Tuner_FrF) Error: %s", sdrplay_api_GetErrorString(err));
@@ -722,7 +727,8 @@ double SoapySDRPlay::getFrequency(const int direction, const size_t channel, con
 
     if (name == "RF")
     {
-        return (double)chParams->tunerParams.rfFreq.rfHz;
+        sdrplay_api_RxChannelParamsT *chp = getChParams(channel);
+        return (double)chp->tunerParams.rfFreq.rfHz;
     }
     else if (name == "CORR")
     {
@@ -802,6 +808,7 @@ void SoapySDRPlay::setSampleRate(const int direction, const size_t channel, cons
 
        sdrplay_api_Bw_MHzT bwType = getBwEnumForRate(output_sample_rate);
 
+       sdrplay_api_RxChannelParamsT *chp = getChParams(channel);
        sdrplay_api_ReasonForUpdateT reasonForUpdate = sdrplay_api_Update_None;
        bool waitForUpdate = false;
        if (deviceParams->devParams && input_sample_rate != deviceParams->devParams->fsFreq.fsHz)
@@ -810,26 +817,26 @@ void SoapySDRPlay::setSampleRate(const int direction, const size_t channel, cons
           reasonForUpdate = (sdrplay_api_ReasonForUpdateT)(reasonForUpdate | sdrplay_api_Update_Dev_Fs);
           waitForUpdate = true;
        }
-       if (ifType != chParams->tunerParams.ifType)
+       if (ifType != chp->tunerParams.ifType)
        {
-          chParams->tunerParams.ifType = ifType;
+          chp->tunerParams.ifType = ifType;
           reasonForUpdate = (sdrplay_api_ReasonForUpdateT)(reasonForUpdate | sdrplay_api_Update_Tuner_IfType);
        }
-       if (decM != chParams->ctrlParams.decimation.decimationFactor)
+       if (decM != chp->ctrlParams.decimation.decimationFactor)
        {
-          chParams->ctrlParams.decimation.enable = decEnable;
-          chParams->ctrlParams.decimation.decimationFactor = decM;
+          chp->ctrlParams.decimation.enable = decEnable;
+          chp->ctrlParams.decimation.decimationFactor = decM;
           if (ifType == sdrplay_api_IF_Zero) {
-              chParams->ctrlParams.decimation.wideBandSignal = 1;
+              chp->ctrlParams.decimation.wideBandSignal = 1;
           }
           else {
-              chParams->ctrlParams.decimation.wideBandSignal = 0;
+              chp->ctrlParams.decimation.wideBandSignal = 0;
           }
           reasonForUpdate = (sdrplay_api_ReasonForUpdateT)(reasonForUpdate | sdrplay_api_Update_Ctrl_Decimation);
        }
-       if (bwType != chParams->tunerParams.bwType)
+       if (bwType != chp->tunerParams.bwType)
        {
-          chParams->tunerParams.bwType = bwType;
+          chp->tunerParams.bwType = bwType;
           reasonForUpdate = (sdrplay_api_ReasonForUpdateT)(reasonForUpdate | sdrplay_api_Update_Tuner_BwType);
        }
        if (reasonForUpdate != sdrplay_api_Update_None)
@@ -842,7 +849,7 @@ void SoapySDRPlay::setSampleRate(const int direction, const size_t channel, cons
              // 2,685,312 and 2,685,313 the rx_callbacks stop for some
              // reason
              fs_changed = 0;
-             sdrplay_api_ErrT err = sdrplay_api_Update(device.dev, device.tuner, reasonForUpdate, sdrplay_api_Update_Ext1_None);
+             sdrplay_api_ErrT err = sdrplay_api_Update(device.dev, getChTuner(channel), reasonForUpdate, sdrplay_api_Update_Ext1_None);
              if (err != sdrplay_api_Success)
              {
                  SoapySDR_logf(SOAPY_SDR_WARNING, "sdrplay_api_Update(%08x) Error: %s", reasonForUpdate, sdrplay_api_GetErrorString(err));
@@ -870,27 +877,28 @@ void SoapySDRPlay::setSampleRate(const int direction, const size_t channel, cons
 double SoapySDRPlay::getSampleRate(const int direction, const size_t channel) const
 {
    double fsHz = deviceParams->devParams ? deviceParams->devParams->fsFreq.fsHz : device.rspDuoSampleFreq;
-   if ((fsHz == 6.0e6 && chParams->tunerParams.ifType == sdrplay_api_IF_1_620) ||
-       (fsHz == 8.0e6 && chParams->tunerParams.ifType == sdrplay_api_IF_2_048))
+   sdrplay_api_RxChannelParamsT *chp = getChParams(channel);
+   if ((fsHz == 6.0e6 && chp->tunerParams.ifType == sdrplay_api_IF_1_620) ||
+       (fsHz == 8.0e6 && chp->tunerParams.ifType == sdrplay_api_IF_2_048))
    {
       fsHz = 2.0e6;
    }
    else if (!(fsHz >= 2.0e6 &&
-              chParams->tunerParams.ifType == sdrplay_api_IF_Zero &&
+              chp->tunerParams.ifType == sdrplay_api_IF_Zero &&
               (device.hwVer != SDRPLAY_RSPduo_ID || device.rspDuoMode == sdrplay_api_RspDuoMode_Single_Tuner)
            ))
    {
-      SoapySDR_logf(SOAPY_SDR_ERROR, "Invalid sample rate and/or IF setting - fsHz=%lf ifType=%d hwVer=%d rspDuoMode=%d rspDuoSampleFreq=%lf", fsHz, chParams->tunerParams.ifType, device.hwVer, device.rspDuoMode, device.rspDuoSampleFreq);
+      SoapySDR_logf(SOAPY_SDR_ERROR, "Invalid sample rate and/or IF setting - fsHz=%lf ifType=%d hwVer=%d rspDuoMode=%d rspDuoSampleFreq=%lf", fsHz, chp->tunerParams.ifType, device.hwVer, device.rspDuoMode, device.rspDuoSampleFreq);
       throw std::runtime_error("Invalid sample rate and/or IF setting");
    }
 
-   if (!chParams->ctrlParams.decimation.enable)
+   if (!chp->ctrlParams.decimation.enable)
    {
       return fsHz;
    }
    else
    {
-      return fsHz / chParams->ctrlParams.decimation.decimationFactor;
+      return fsHz / chp->ctrlParams.decimation.decimationFactor;
    }
 }
 
@@ -1914,6 +1922,62 @@ std::string SoapySDRPlay::readSetting(const std::string &key) const
     return "";
 }
 
+// Per-channel settings: currently only rfnotch_ctrl is supported, and only for
+// RSPduo in DT-IR mode where each tuner has an independent FM notch filter.
+// This allows enabling the notch on the target tuner (ch1) without affecting the
+// sync tuner (ch0) that needs to receive FM broadcast signals.
+void SoapySDRPlay::writeChannelSetting(const int direction, const size_t channel,
+                                       const std::string &key, const std::string &value)
+{
+    if (device.hwVer != SDRPLAY_RSPduo_ID || !rspDuoDualTunerIndependentRx)
+    {
+        // Fall through to device-wide setting for non-DT-IR modes.
+        writeSetting(key, value);
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(_general_state_mutex);
+
+    if (key == "rfnotch_ctrl")
+    {
+        unsigned char notchEn = (value == "false") ? 0 : 1;
+        sdrplay_api_RxChannelParamsT *cp = getChParams(channel);
+        sdrplay_api_TunerSelectT tuner   = getChTuner(channel);
+        cp->rspDuoTunerParams.rfNotchEnable = notchEn;
+        if (streamActive)
+        {
+            sdrplay_api_ErrT err = sdrplay_api_Update(device.dev, tuner,
+                sdrplay_api_Update_RspDuo_RfNotchControl,
+                sdrplay_api_Update_Ext1_None);
+            if (err != sdrplay_api_Success)
+            {
+                SoapySDR_logf(SOAPY_SDR_WARNING,
+                    "writeChannelSetting rfnotch_ctrl ch%zu: %s",
+                    channel, sdrplay_api_GetErrorString(err));
+            }
+        }
+    }
+    else
+    {
+        SoapySDR_logf(SOAPY_SDR_WARNING,
+            "writeChannelSetting: unsupported key '%s' for channel %zu",
+            key.c_str(), channel);
+    }
+}
+
+std::string SoapySDRPlay::readChannelSetting(const int direction, const size_t channel,
+                                             const std::string &key) const
+{
+    if (device.hwVer == SDRPLAY_RSPduo_ID && rspDuoDualTunerIndependentRx &&
+        key == "rfnotch_ctrl")
+    {
+        std::lock_guard<std::mutex> lock(_general_state_mutex);
+        const sdrplay_api_RxChannelParamsT *cp = getChParams(channel);
+        return cp->rspDuoTunerParams.rfNotchEnable ? "true" : "false";
+    }
+    return readSetting(key);
+}
+
 void SoapySDRPlay::selectDevice(const std::string &serial,
                                 const std::string &mode,
                                 const std::string &antenna)
@@ -1923,6 +1987,7 @@ void SoapySDRPlay::selectDevice(const std::string &serial,
     if (mode == "SL") {
         rspDeviceId += "/S";
     }
+    rspDuoDualTunerIndependentRx = false;
 
     sdrplay_api_TunerSelectT tuner;
     sdrplay_api_RspDuoModeT rspDuoMode;
@@ -1944,6 +2009,13 @@ void SoapySDRPlay::selectDevice(const std::string &serial,
         tuner = sdrplay_api_Tuner_Both;
         rspDuoMode = sdrplay_api_RspDuoMode_Dual_Tuner;
         rspDuoSampleFreq = 6000000;
+    }
+    else if (mode == "DT-IR")
+    {
+        tuner = sdrplay_api_Tuner_Both;
+        rspDuoMode = sdrplay_api_RspDuoMode_Dual_Tuner;
+        rspDuoSampleFreq = 6000000;
+        rspDuoDualTunerIndependentRx = true;
     }
     else if (mode == "MA")
     {
@@ -2142,6 +2214,30 @@ void SoapySDRPlay::selectDevice(sdrplay_api_TunerSelectT tuner,
     chParams = device.tuner == sdrplay_api_Tuner_B ? deviceParams->rxChannelB : deviceParams->rxChannelA;
 
     return;
+}
+
+sdrplay_api_RxChannelParamsT *SoapySDRPlay::getChParams(const size_t channel) const
+{
+    if (device.hwVer == SDRPLAY_RSPduo_ID &&
+        device.rspDuoMode == sdrplay_api_RspDuoMode_Dual_Tuner &&
+        rspDuoDualTunerIndependentRx)
+    {
+        if (channel == 0) return deviceParams->rxChannelA;
+        if (channel == 1) return deviceParams->rxChannelB;
+    }
+    return chParams;
+}
+
+sdrplay_api_TunerSelectT SoapySDRPlay::getChTuner(const size_t channel) const
+{
+    if (device.hwVer == SDRPLAY_RSPduo_ID &&
+        device.rspDuoMode == sdrplay_api_RspDuoMode_Dual_Tuner &&
+        rspDuoDualTunerIndependentRx)
+    {
+        if (channel == 0) return sdrplay_api_Tuner_A;
+        if (channel == 1) return sdrplay_api_Tuner_B;
+    }
+    return device.tuner;
 }
 
 void SoapySDRPlay::releaseDevice()

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -90,6 +90,8 @@ SoapySDRPlay::SoapySDRPlay(const SoapySDR::Kwargs &args)
 
     device_unavailable = false;
 
+    master_initialised = false;
+
     cacheKey = serNo;
     if (hwVer == SDRPLAY_RSPduo_ID) cacheKey += "@" + args.at("mode");
     SoapySDRPlay_getClaimedSerials().insert(cacheKey);
@@ -1712,6 +1714,33 @@ void SoapySDRPlay::writeSetting(const std::string &key, const std::string &value
          }
       }
    }
+   else if (key == "rfnotch_ctrl_ch1")
+   {
+      // DT-IR only: enable/disable the FM notch filter on Tuner B (channel 1)
+      // without affecting Tuner A (channel 0), which may need to receive FM.
+      if (device.hwVer == SDRPLAY_RSPduo_ID && rspDuoDualTunerIndependentRx &&
+          deviceParams->rxChannelB)
+      {
+         unsigned char notchEn = (value == "false") ? 0 : 1;
+         deviceParams->rxChannelB->rspDuoTunerParams.rfNotchEnable = notchEn;
+         if (streamActive)
+         {
+            sdrplay_api_ErrT err = sdrplay_api_Update(device.dev, sdrplay_api_Tuner_B,
+                sdrplay_api_Update_RspDuo_RfNotchControl,
+                sdrplay_api_Update_Ext1_None);
+            if (err != sdrplay_api_Success)
+            {
+               SoapySDR_logf(SOAPY_SDR_WARNING, "rfnotch_ctrl_ch1 update Error: %s",
+                   sdrplay_api_GetErrorString(err));
+            }
+         }
+      }
+      else
+      {
+         SoapySDR_logf(SOAPY_SDR_WARNING,
+             "rfnotch_ctrl_ch1 is only supported for RSPduo in DT-IR mode");
+      }
+   }
    else if (key == "rfnotch_ctrl")
    {
       unsigned char notchEn;
@@ -1844,7 +1873,22 @@ std::string SoapySDRPlay::readSetting(const std::string &key) const
     }
     else
 #endif
-    if (key == "iqcorr_ctrl")
+    if (key == "master_initialised")
+    {
+        // RSPduo Master/Slave mode: returns "true" once the sdrplay_api_MasterInitialised
+        // event has been received, signalling that the Slave can call SelectDevice().
+        return master_initialised.load() ? "true" : "false";
+    }
+    else if (key == "rfnotch_ctrl_ch1")
+    {
+       if (device.hwVer == SDRPLAY_RSPduo_ID && rspDuoDualTunerIndependentRx &&
+           deviceParams->rxChannelB)
+       {
+          return deviceParams->rxChannelB->rspDuoTunerParams.rfNotchEnable ? "true" : "false";
+       }
+       return "false";
+    }
+    else if (key == "iqcorr_ctrl")
     {
        if (chParams->ctrlParams.dcOffset.IQenable == 0) return "false";
        else                                             return "true";

--- a/SoapySDRPlay.hpp
+++ b/SoapySDRPlay.hpp
@@ -330,6 +330,10 @@ private:
     bool device_unavailable;
     const int updateTimeout = 500;   // 500ms timeout for updates
 
+    // set by ev_callback when sdrplay_api_MasterInitialised fires; signals
+    // that the Slave device can now call sdrplay_api_SelectDevice()
+    std::atomic_bool master_initialised;
+
 public:
 
    /*******************************************************************

--- a/SoapySDRPlay.hpp
+++ b/SoapySDRPlay.hpp
@@ -225,6 +225,10 @@ public:
 
     void writeSetting(const std::string &key, const std::string &value);
 
+    void writeChannelSetting(const int direction, const size_t channel, const std::string &key, const std::string &value);
+
+    std::string readChannelSetting(const int direction, const size_t channel, const std::string &key) const;
+
     void changeRspDuoMode(const std::string &rspDuoModeString,
                           bool resetDevice);
 
@@ -272,6 +276,9 @@ private:
                       double rspDuoSampleFreq,
                       sdrplay_api_DeviceParamsT *thisDeviceParams);
 
+    sdrplay_api_RxChannelParamsT *getChParams(const size_t channel) const;
+    sdrplay_api_TunerSelectT getChTuner(const size_t channel) const;
+
     void releaseDevice();
 
 #ifdef SHOW_SERIAL_NUMBER_IN_MESSAGES
@@ -287,6 +294,7 @@ private:
     sdrplay_api_DeviceT device;
     sdrplay_api_DeviceParamsT *deviceParams;
     sdrplay_api_RxChannelParamsT *chParams;
+    bool rspDuoDualTunerIndependentRx;
     int hwVer;
     std::string serNo;
     std::string cacheKey;

--- a/Streaming.cpp
+++ b/Streaming.cpp
@@ -105,7 +105,7 @@ void SoapySDRPlay::rx_callback(short *xi, short *xq,
     }
 
     int spaceReqd = numSamples * elementsPerSample * shortsPerWord;
-    if ((stream->buffs[stream->tail].size() + spaceReqd) >= (bufferLength / chParams->ctrlParams.decimation.decimationFactor))
+    if ((stream->buffs[stream->tail].size() + spaceReqd) >= (bufferLength / getChParams(stream->channel)->ctrlParams.decimation.decimationFactor))
     {
        // increment the tail pointer and buffer count
        stream->tail = (stream->tail + 1) % numBuffers;
@@ -193,7 +193,13 @@ void SoapySDRPlay::ev_callback(sdrplay_api_EventT eventId, sdrplay_api_TunerSele
     }
     else if (eventId == sdrplay_api_RspDuoModeChange)
     {
-        if (params->rspDuoModeParams.modeChangeType == sdrplay_api_MasterDllDisappeared)
+        if (params->rspDuoModeParams.modeChangeType == sdrplay_api_MasterInitialised)
+        {
+            // Master Init complete -- Slave may now call sdrplay_api_SelectDevice()
+            SoapySDR_log(SOAPY_SDR_INFO, "RSPduo Master initialised; Slave can now SelectDevice.");
+            master_initialised = true;
+        }
+        else if (params->rspDuoModeParams.modeChangeType == sdrplay_api_MasterDllDisappeared)
         {
             // Notify readStream() that the master stream has been removed
             // so that the application can be closed gracefully
@@ -359,6 +365,14 @@ int SoapySDRPlay::activateStream(SoapySDR::Stream *stream,
     chParams->tunerParams.dcOffsetTuner.dcCal = 4;
     chParams->tunerParams.dcOffsetTuner.speedUp = 0;
     chParams->tunerParams.dcOffsetTuner.trackTime = 63;
+    if (device.hwVer == SDRPLAY_RSPduo_ID &&
+        device.rspDuoMode == sdrplay_api_RspDuoMode_Dual_Tuner &&
+        rspDuoDualTunerIndependentRx)
+    {
+        deviceParams->rxChannelB->tunerParams.dcOffsetTuner.dcCal = 4;
+        deviceParams->rxChannelB->tunerParams.dcOffsetTuner.speedUp = 0;
+        deviceParams->rxChannelB->tunerParams.dcOffsetTuner.trackTime = 63;
+    }
 
     sdrplay_api_CallbackFnsT cbFns;
     cbFns.StreamACbFn = _rx_callback_A;


### PR DESCRIPTION
## RSPduo Dual-Tuner Independent-RX (DT-IR) submode + MasterInitialised event

This PR adds two related features for RSPduo users who need to run both tuners
simultaneously on independent frequencies.

---

### 1. Dual-Tuner Independent-RX (DT-IR) submode

A new device mode string `"DT-IR"` selects `sdrplay_api_RspDuoMode_Dual_Tuner`
with `sdrplay_api_Tuner_Both`, and activates per-channel parameter dispatch.

**The problem with existing Dual Tuner mode:**
The existing `"DT"` mode opens both tuners but all Settings, gain, frequency,
and sample rate operations act on `chParams` (Tuner A) and use `device.tuner`
in `sdrplay_api_Update()` calls.  Channel 1 (Tuner B) cannot be tuned or
configured independently.

**What DT-IR adds:**
- `getChParams(channel)` — returns `rxChannelA` or `rxChannelB` based on the
  channel index when in DT-IR mode; returns `chParams` otherwise (no change to
  existing code paths).
- `getChTuner(channel)` — returns `sdrplay_api_Tuner_A` or `sdrplay_api_Tuner_B`
  for DT-IR; returns `device.tuner` otherwise.
- All gain, AGC, frequency, sample rate, and decimation operations updated to
  call `getChParams(channel)` and `getChTuner(channel)` so they correctly
  address whichever tuner the caller specifies.
- DC offset calibration initialised for `rxChannelB` in `activateStream()`.
- `rx_callback` uses `getChParams(stream->channel)` for the buffer-full check.

**Backwards compatibility:** All existing modes (`"ST"`, `"DT"`, `"MA"`,
`"SL"`) are completely unaffected; `getChParams` and `getChTuner` fall through
to the existing `chParams` / `device.tuner` values when `rspDuoDualTunerIndependentRx`
is false.

---

### 2. Per-channel FM notch control for DT-IR mode

In DT-IR mode both tuners have independent hardware FM broadcast notch filters
(88–108 MHz).  The existing device-wide `writeSetting("rfnotch_ctrl")` only
reaches `rxChannelA`; there is no way to control `rxChannelB`'s filter.

This PR adds:
- `writeChannelSetting(RX, ch, "rfnotch_ctrl", "true"/"false")` — sets
  `rfNotchEnable` on the correct tuner and calls `sdrplay_api_Update` with the
  correct `sdrplay_api_TunerSelectT`.  For non-DT-IR devices and modes the
  call falls through to the existing device-wide `writeSetting`.
- `readChannelSetting(RX, ch, "rfnotch_ctrl")` — reads back per-tuner notch state.
- `writeSetting("rfnotch_ctrl_ch1", ...)` / `readSetting("rfnotch_ctrl_ch1")` —
  convenience device-wide keys that always address Tuner B directly (DT-IR only).

**Motivation:** applications that use Tuner A to receive an FM broadcast station
as a timing reference must leave Tuner A's FM notch disabled, while Tuner B
(receiving a different band) should suppress FM bleed-through with its notch
enabled.

---

### 3. `readSetting("master_initialised")` for Master/Slave sequencing

When the RSPduo is opened in Master mode, a subsequent call to
`sdrplay_api_SelectDevice()` for the Slave will fail unless the Master's event
callback has first received `sdrplay_api_MasterInitialised`.  The API
documentation notes this requirement but there is no way for the application to
know when this event has fired.

This PR:
- Handles `sdrplay_api_MasterInitialised` in `ev_callback`, setting an
  `std::atomic_bool master_initialised` to `true` and logging at INFO level.
- Exposes the flag via `readSetting("master_initialised")`, returning `"true"`
  or `"false"`, so the application can poll before calling `SelectDevice()` on
  the Slave instance.

---

### Files changed

| File | Change |
|------|--------|
| `Settings.cpp` | `DT-IR` mode in `selectDevice()`; `getChParams`/`getChTuner` implementations; all channel-aware refactors; `writeChannelSetting`/`readChannelSetting`; `rfnotch_ctrl_ch1` and `master_initialised` settings |
| `SoapySDRPlay.hpp` | Declarations for `getChParams`, `getChTuner`, `writeChannelSetting`, `readChannelSetting`; `rspDuoDualTunerIndependentRx` bool member; `master_initialised` atomic bool |
| `Streaming.cpp` | `rx_callback` buffer check uses `getChParams`; `activateStream` DC offset init for channel B; `MasterInitialised` event handler in `ev_callback` |